### PR TITLE
typos e

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,15 +48,15 @@
                     <li>An encrypted chat room</li>
                     <li>A programming language</li>
                     <li>A small video sharing platform</li>
-                    <li>Multiple good logo's</li>
+                    <li>Multiple good logos</li>
                     <li>And more!</li>
                 </ul>
             </p>
 
     <footer>
         <p>
-            Scratch is NOT owned by the CollabOS. Scratch is owned by MIT.
-            Any other mentioned company's, products, or services are owned by there respective owners.
+            Scratch is NOT owned by the CollabOS team. Scratch is owned by MIT.
+            Any other mentioned companies, products, or services are owned by their respective owners.
         </p>
     </footer>
 


### PR DESCRIPTION
Scratch is NOT owned by the CollabOS team. Scratch is owned by MIT.
            Any other mentioned companies, products, or services are owned by their respective owners. (here for fixing other pages)